### PR TITLE
20230924 wowalswjd (김민정) 회원가입/로그인 페이지에 로고만 있는 헤더 추가

### DIFF
--- a/src/api/member.js
+++ b/src/api/member.js
@@ -4,6 +4,8 @@ import getS3ImgUrl from "./s3upload";
 export const getMyProfile = async () => {
   try {
     const res = await client.get(`/members/me`);
+    // localStorage에 member role 추가
+    localStorage.setItem("role", res.data.role);
     return res.data;
   } catch (err) {
     console.log("에러 발생", err);

--- a/src/api/url.js
+++ b/src/api/url.js
@@ -1,1 +1,0 @@
-export const API_URL = "https://api.snapspot.co.kr/";

--- a/src/components/common/Header.js
+++ b/src/components/common/Header.js
@@ -9,7 +9,7 @@ import menu from "../../assets/header/menu.png";
 import HomeMenu from "./HomeMenu";
 import SearchBox from "./SearchBox";
 
-const Header = () => {
+const Header = (props) => {
   const navigate = useNavigate();
   const isMobile = useMobileDetection();
   const [isHomeMenuOpen, setIsHomeMenuOpen] = useState(false);
@@ -46,24 +46,30 @@ const Header = () => {
             />
           </div>
           <MobileLogo src={mobilelogo} alt="로고" onClick={onClickLogo} />
-          {isMobile ? null : <SearchBox />}
-          <Menu>
-            <div className="subMenu" onClick={onClickPhotogreapher}>
-              사진작가
-            </div>
-            <div className="subMenu" onClick={onClickFeed}>
-              피드
-            </div>
-            <img
-              className="mypage"
-              onClick={onClickMyPage}
-              src={profile}
-              alt="마이페이지"
-            />
-            <img className="menu" onClick={openModal} src={menu} alt="메뉴" />
-          </Menu>
+          <RightSection className={props.isAuthPage ? "hidden" : ""}>
+            {isMobile ? null : <SearchBox />}
+          </RightSection>
+          <RightSection className={props.isAuthPage ? "hidden" : ""}>
+            <Menu>
+              <div className="subMenu" onClick={onClickPhotogreapher}>
+                사진작가
+              </div>
+              <div className="subMenu" onClick={onClickFeed}>
+                피드
+              </div>
+              <img
+                className="mypage"
+                onClick={onClickMyPage}
+                src={profile}
+                alt="마이페이지"
+              />
+              <img className="menu" onClick={openModal} src={menu} alt="메뉴" />
+            </Menu>
+          </RightSection>
         </Main>
-        {isMobile ? <SearchBox /> : null}
+        <RightSection className={props.isAuthPage ? "hidden" : ""}>
+          {isMobile ? <SearchBox /> : null}
+        </RightSection>
       </HeaderDiv>
       {isMobile && isHomeMenuOpen && (
         <HomeMenu
@@ -193,5 +199,12 @@ const MobileLogo = styled.img`
     width: 1.84rem;
     height: 1.5rem;
     margin-right: 2rem;
+  }
+`;
+
+// 로고 오른쪽 섹션 - 회원가입/로그인 페이지일 경우 보이지 않음
+const RightSection = styled.div`
+  &.hidden {
+    visibility: hidden;
   }
 `;

--- a/src/pages/LoginPage/LoginPage.js
+++ b/src/pages/LoginPage/LoginPage.js
@@ -3,21 +3,34 @@ import { styled } from "styled-components";
 import Logo from "../../assets/header/logo.png";
 import LoginForm from "../../components/Login/LoginForm";
 import useMobileDetection from "../../components/common/mobileDetection";
+import { useNavigate } from "react-router-dom";
+import Header from "../../components/common/Header";
 
 const LoginPage = () => {
+  const navigate = useNavigate();
+
   // 실시간 모바일 크기 알아오기
   const isMobile = useMobileDetection();
+
+  // 로고 클릭 시 MainPage로 이동
+  const onClickLogo = () => {
+    navigate(`/`);
+  };
+
   return (
-    <Wrapper>
-      <div className="container">
-        {isMobile ? (
-          <LogoImage src={Logo} alt="snapspot" />
-        ) : (
-          <MainText>로그인</MainText>
-        )}
-        <LoginForm/>
-      </div>
-    </Wrapper>
+    <>
+      {isMobile ? null : <Header isAuthPage={true} />}
+      <Wrapper>
+        <div className="container">
+          {isMobile ? (
+            <LogoImage src={Logo} alt="snapspot" onClick={onClickLogo}/>
+          ) : (
+            <MainText>로그인</MainText>
+          )}
+          <LoginForm />
+        </div>
+      </Wrapper>
+    </>
   );
 };
 
@@ -51,4 +64,6 @@ const LogoImage = styled.img`
   display: block;
   margin-left: auto;
   margin-right: auto;
+
+  cursor: pointer;
 `;

--- a/src/pages/SignUpPage/SignUpInfoPage.js
+++ b/src/pages/SignUpPage/SignUpInfoPage.js
@@ -2,11 +2,13 @@ import React from "react";
 import SignUpForm from "../../components/SignUp/SignUpForm";
 import { styled } from "styled-components";
 import Logo from "../../assets/header/logo.png";
-import { useParams } from "react-router";
+import { useParams, useNavigate } from "react-router-dom";
 import useMobileDetection from "../../components/common/mobileDetection";
+import Header from "../../components/common/Header";
 
 const SignUpInfoPage = () => {
   const params = useParams();
+  const navigate = useNavigate();
 
   // 이전 페이지에서 받아온 멤버 유형(customer, photographer)
   const memberType = params.memberType;
@@ -14,17 +16,25 @@ const SignUpInfoPage = () => {
   // 실시간 모바일 크기 알아오기
   const isMobile = useMobileDetection();
 
+  // 로고 클릭 시 MainPage로 이동
+  const onClickLogo = () => {
+    navigate(`/`);
+  };
+
   return (
-    <Wrapper>
-      <div className="container">
-        {isMobile ? (
-          <LogoImage src={Logo} alt="snapspot" />
-        ) : (
-          <MainText>회원가입</MainText>
-        )}
-        <SignUpForm memberType={memberType}/>
-      </div>
-    </Wrapper>
+    <>
+      {isMobile ? null : <Header isAuthPage={true} />}
+      <Wrapper>
+        <div className="container">
+          {isMobile ? (
+            <LogoImage src={Logo} alt="snapspot" onClick={onClickLogo} />
+          ) : (
+            <MainText>회원가입</MainText>
+          )}
+          <SignUpForm memberType={memberType} />
+        </div>
+      </Wrapper>
+    </>
   );
 };
 
@@ -58,4 +68,6 @@ const LogoImage = styled.img`
   display: block;
   margin-left: auto;
   margin-right: auto;
+
+  cursor: pointer;
 `;

--- a/src/pages/SignUpPage/SignUpMemberPage.js
+++ b/src/pages/SignUpPage/SignUpMemberPage.js
@@ -7,6 +7,7 @@ import M_Photographer from "../../assets/signup/photographer_mobile.png";
 import Arrow from "../../assets/signup/arrow_left.png";
 import { useNavigate } from "react-router";
 import useMobileDetection from "../../components/common/mobileDetection";
+import Header from "../../components/common/Header";
 
 const SignUpMemberPage = () => {
   const navigate = useNavigate();
@@ -21,35 +22,38 @@ const SignUpMemberPage = () => {
   const isMobile = useMobileDetection();
 
   return (
-    <Wrapper>
-      <div className="container">
-        <ArrowBack src={Arrow} alt="뒤로가기" />
-        <MainText>회원가입 유형을 골라주세요!</MainText>
-        <MainDiv>
-          <MemberDiv>
-            <MemberImage
-              src={isMobile ? M_Customer : Customer}
-              alt="고객"
-              onClick={() => {
-                // 고객 - customer에서 member로 변경 (이미지 이름은 customer로 유지)
-                navigateToInfoPage("member");
-              }}
-            />
-            <MemberText color="#008EDE">인생사진을 찍고 싶어요!</MemberText>
-          </MemberDiv>
-          <MemberDiv>
-            <MemberImage
-              src={isMobile ? M_Photographer : Photographer}
-              alt="작가"
-              onClick={() => {
-                navigateToInfoPage("photographer");
-              }}
-            />
-            <MemberText color="#3C3AAC">멋진 사진을 찍어드릴게요!</MemberText>
-          </MemberDiv>
-        </MainDiv>
-      </div>
-    </Wrapper>
+    <>
+      <Header isAuthPage={true} />
+      <Wrapper>
+        <div className="container">
+          {/* <ArrowBack src={Arrow} alt="뒤로가기" /> */}
+          <MainText>회원가입 유형을 골라주세요!</MainText>
+          <MainDiv>
+            <MemberDiv>
+              <MemberImage
+                src={isMobile ? M_Customer : Customer}
+                alt="고객"
+                onClick={() => {
+                  // 고객 - customer에서 member로 변경 (이미지 이름은 customer로 유지)
+                  navigateToInfoPage("member");
+                }}
+              />
+              <MemberText color="#008EDE">인생사진을 찍고 싶어요!</MemberText>
+            </MemberDiv>
+            <MemberDiv>
+              <MemberImage
+                src={isMobile ? M_Photographer : Photographer}
+                alt="작가"
+                onClick={() => {
+                  navigateToInfoPage("photographer");
+                }}
+              />
+              <MemberText color="#3C3AAC">멋진 사진을 찍어드릴게요!</MemberText>
+            </MemberDiv>
+          </MainDiv>
+        </div>
+      </Wrapper>
+    </>
   );
 };
 
@@ -60,8 +64,13 @@ const Wrapper = styled.div`
   justify-content: center;
   align-items: center;
 
-  // PC, 모바일 모두 통일
-  height: 100vh;
+  // PC : 100vh - Header height
+  height: calc(100vh - 6.125rem);
+
+  // Mobile : 100vh - Header height - SearchBox height
+  @media screen and (max-width: 768px) {
+    height: calc(100vh - 6.125rem - 2.375rem);
+  }
 `;
 
 const MainText = styled.div`


### PR DESCRIPTION
## 📌 작업사항
- 회원가입 멤버 선택 페이지, 회원가입 정보 입력 페이지, 로그인 페이지에 로고만 있는 헤더 추가
- Header.js에 관련 코드 일부 추가
- 고객 계정 정보 조회 api에 회원의 role을 localStorage에 저장하는 코드를 추가
- url.js 삭제

## 📸 스크린샷(선택)

<!-- 스크린샷이 필요한 작업이면 스크린샷을 첨부해주세요 -->
- PC
![image](https://github.com/Snap-Spot/SnapSpot-Frontend/assets/81233784/e32ea890-3a52-4e93-ae04-669bfd1e7683)

- 모바일
![image](https://github.com/Snap-Spot/SnapSpot-Frontend/assets/81233784/640dff3d-4d69-4b35-a530-f2d6d200f1f4)

- 회원가입 정보 입력 페이지, 로그인 페이지 모바일의 경우 헤더를 따로 추가하지 않고 snapspot 로고 클릭 하면 메인 페이지로 이동하도록 하였습니다.
![image](https://github.com/Snap-Spot/SnapSpot-Frontend/assets/81233784/e3599340-4a50-45b1-9679-d307983be48e)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

<!-- 참고할 사항이 있다면 적어주세요 -->
로그인 성공 시 회원의 role을 localStorage에 저장해달라고 요청하셨었는데, 로그인 응답에는 role이 존재하지 않은 것 같습니다..
고객 계정 정보 조회 api get할 때 localStorage에 회원의 role을 저장하는 방식으로 일단 코드 추가했는데, 자유롭게 수정해도 됩니다!

## ✅ PR 체크 리스트

- [x] PR 제목을 규칙에 맞게 작성
- [x] label 설정
- [x] 작업한 사람 모두를 Assign
- [x] Code Review 요청
