### PR TITLE
# 20231012 songing01 (송지민) 모바일에서 브라우저 기본 푸터에 가려 끝까지 스크롤이 안되는 이슈 해결

### DIFF
--- a/src/components/Mypage-User/Modals/ModalTemplate.js
+++ b/src/components/Mypage-User/Modals/ModalTemplate.js
@@ -22,15 +22,19 @@ const ModalTemplate = ({ isOverflow = 0, title, content, setShowModal }) => {
     setShowModal(false);
   };
   return (
-    <Wrapper onClick={closeModal}>
-      <Modal $isOverflow={isOverflow} onClick={(e) => e.stopPropagation()}>
-        <div className="title">
-          {title}
-          <img src={close} alt="" onClick={closeModal} />
+    <>
+      <Wrapper onClick={closeModal}>
+        <div className="space-alloc">
+          <Modal $isOverflow={isOverflow} onClick={(e) => e.stopPropagation()}>
+            <div className="title">
+              {title}
+              <img src={close} alt="" onClick={closeModal} />
+            </div>
+            {content}
+          </Modal>
         </div>
-        {content}
-      </Modal>
-    </Wrapper>
+      </Wrapper>
+    </>
   );
 };
 
@@ -53,19 +57,26 @@ const Wrapper = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  overflow-y: auto; //수정
+  overflow-y: scroll; //수정
+
+  .space-alloc {
+    position: absolute;
+    top: 14rem;
+
+    display: flex;
+    justify-content: center;
+    align-items: start;
+    width: 100vw;
+    height: 1000px;
+  }
 `;
 
 const Modal = styled.div`
-  position: absolute;
-  top: 14rem;
+  /* position: absolute;
+  top: 14rem; */
 
-  /* margin-top: ${(props) => (props.$isOverflow === 1 ? "400px" : "0px")};
-  @media (max-width: 768px) {
-    //모바일
-    margin-top: ${(props) => (props.$isOverflow === 1 ? "200px" : "0px")};
-  } */
   width: 880px;
+
   display: flex;
   flex-direction: column;
   padding: 40px 32px;


### PR DESCRIPTION
## 📌 작업사항

모바일에서 브라우저 기본 푸터에 가려 끝까지 스크롤이 안되는 이슈 해결 :  모달을 감싼 1000px height를 설정한 컨테이너를 추가.

## ✅ PR 체크 리스트

- [X] PR 제목을 규칙에 맞게 작성
- [X] label 설정
- [X] 작업한 사람 모두를 Assign
- [X] Code Review 요청
